### PR TITLE
Enable rbac to get proxy running.

### DIFF
--- a/hub/config.yaml
+++ b/hub/config.yaml
@@ -1,7 +1,7 @@
 version: "v0.5.0"
 
 rbac:
-  enabled: false
+  enabled: true
 
 prePuller:
   enabled: false


### PR DESCRIPTION
"It seems the cluster it is running with Authorization enabled (like
RBAC) and there is no permissions for the ingress controller. Please
check the configuration"